### PR TITLE
fix: license philosophy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Shorebird projects are licensed for use under either Apache License, Version 2.0
 
 See our license philosophy for more information on why we license files this
 way:
-https://github.com/shorebirdtech/handbook/blob/main/README.md#licensing-philosophy
+https://github.com/shorebirdtech/handbook/blob/main/engineering.md#licensing-philosophy


### PR DESCRIPTION
looks like that section moved from README to Engineering